### PR TITLE
ci: retire master branch — point release workflow and docs at main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,15 +3,15 @@ name: Create Release
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     types: [closed]
     branches:
-      - master
+      - main
 
 jobs:
   create-release:
-    # Only run when PR is merged or direct push to master
+    # Only run when PR is merged or direct push to main
     if: github.event_name == 'push' || (github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
 
@@ -32,12 +32,12 @@ jobs:
       - name: Check if tag exists
         id: check_tag
         run: |
-          if git rev-parse "v${{ steps.get_version.outputs.version }}" >/dev/null 2>&1; then
+          if git rev-parse "${{ steps.get_version.outputs.version }}" >/dev/null 2>&1; then
             echo "exists=true" >> $GITHUB_OUTPUT
-            echo "Tag v${{ steps.get_version.outputs.version }} already exists"
+            echo "Tag ${{ steps.get_version.outputs.version }} already exists"
           else
             echo "exists=false" >> $GITHUB_OUTPUT
-            echo "Tag v${{ steps.get_version.outputs.version }} does not exist"
+            echo "Tag ${{ steps.get_version.outputs.version }} does not exist"
           fi
 
       - name: Create tag
@@ -45,8 +45,8 @@ jobs:
         run: |
           git config user.name github-actions[bot]
           git config user.email github-actions[bot]@users.noreply.github.com
-          git tag -a "v${{ steps.get_version.outputs.version }}" -m "Release version ${{ steps.get_version.outputs.version }}"
-          git push origin "v${{ steps.get_version.outputs.version }}"
+          git tag -a "${{ steps.get_version.outputs.version }}" -m "Release version ${{ steps.get_version.outputs.version }}"
+          git push origin "${{ steps.get_version.outputs.version }}"
     
       - name: Extract changelog for version
         id: changelog
@@ -88,8 +88,8 @@ jobs:
         if: steps.check_tag.outputs.exists == 'false'
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: v${{ steps.get_version.outputs.version }}
-          name: v${{ steps.get_version.outputs.version }}
+          tag_name: ${{ steps.get_version.outputs.version }}
+          name: ${{ steps.get_version.outputs.version }}
           body: |
             ${{ steps.changelog.outputs.changelog }}
           draft: false

--- a/doc/Contributor-Guide/Getting-Started.md
+++ b/doc/Contributor-Guide/Getting-Started.md
@@ -124,7 +124,7 @@ Types: `feat`, `fix`, `docs`, `test`, `refactor`, `perf`, `chore`
 7. **Request review** from maintainers
 8. **Address feedback** and update PR
 9. **Squash commits** before merge if requested
-10. **Merge to develop**, then maintainers merge to master
+10. **Merge to develop**, then maintainers merge to main
 
 ### Code Review Process
 

--- a/doc/Contributor-Guide/README.md
+++ b/doc/Contributor-Guide/README.md
@@ -190,7 +190,7 @@ See [Extension-Points.md](Extension-Points.md) for detailed examples.
 - Respond to review feedback
 - Push updates (don't force-push)
 - Wait for approval
-- Maintainer merges to develop, then master
+- Maintainer merges to develop, then main
 
 ## Resources
 

--- a/doc/Contributor-Guide/Submitting-Changes.md
+++ b/doc/Contributor-Guide/Submitting-Changes.md
@@ -162,7 +162,7 @@ Once approved:
 1. **Squash commits** if requested (multiple commits combined)
 2. **Merge to develop** via GitHub
 3. **Delete feature branch**
-4. **Maintainer merges develop → master** periodically
+4. **Maintainer merges develop → main** periodically
 
 ## Changelog Updates
 
@@ -398,15 +398,15 @@ Releases follow semantic versioning: `MAJOR.MINOR.PATCH`
 
 3. **Create release commit**
    ```bash
-   git checkout master
-   git pull origin master
+   git checkout main
+   git pull origin main
    git commit -am "release: version 0.0.37"
    ```
 
 4. **Tag release**
    ```bash
-   git tag -a v0.0.37 -m "Release version 0.0.37"
-   git push origin master --tags
+   git tag -a 0.0.37 -m "Release version 0.0.37"
+   git push origin main --tags
    ```
 
 5. **Create GitHub release**

--- a/doc/Contributor-Guide/Testing-Guide.md
+++ b/doc/Contributor-Guide/Testing-Guide.md
@@ -568,8 +568,8 @@ public function testUserValidation(): void
 Tests run automatically via GitHub Actions:
 
 1. **On every push** to branches
-2. **On pull requests** to develop/master
-3. **Required before merge** to master (checks coverage, failures)
+2. **On pull requests** to develop/main
+3. **Required before merge** to main (checks coverage, failures)
 
 Verify locally before pushing:
 


### PR DESCRIPTION
## Summary
The `master` branch was retired on GitHub (only `develop`, `main`, and feature branches remain). However the release workflow and several docs still referenced it.

- **`release.yml`**: triggered only on `master` — a branch that no longer exists — so release automation has been dead since ~0.0.40. Repointed `push` and `pull_request` triggers to `main`.
- **Tag prefix**: dropped the `v` prefix in `release.yml` (tag-existence check, tag creation, and the `action-gh-release` `tag_name`/`name`). Recent real tags are unprefixed (`0.0.39`, `0.0.40`); the workflow's `v`-prefixed format would have produced an inconsistent `v0.0.x` tag.
- **Docs**: updated `doc/Contributor-Guide/` files that still described merging to `master`.

## Effect
Once this reaches `main`, a version-bumped push to `main` will auto-create the tag and GitHub Release again — no manual tagging.

## Test plan
- [ ] CI: full PHPUnit suite passes
- [ ] After merge to `main`, confirm the "Create Release" workflow fires on the next release push