### PR TITLE
ci: fire release workflow once per merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,15 +4,9 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [closed]
-    branches:
-      - main
 
 jobs:
   create-release:
-    # Only run when PR is merged or direct push to main
-    if: github.event_name == 'push' || (github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
The "Create Release" workflow had both a `push: [main]` and a `pull_request: closed → [main]` trigger. Every PR merge to `main` therefore fired it **twice** — both runs raced to create the same version tag, one succeeding and the other failing with `tag already exists` (observed on the 0.0.41 release).

A single `push: [main]` trigger already covers both PR merges and direct pushes. This drops the redundant `pull_request` trigger and the now-trivial `if: github.event_name == 'push' || ...` guard.

## Effect
One workflow run per release, no spurious red run. No change to release behaviour otherwise.

## Note
Pure CI cleanup — no version bump. Ships with the next release.

## Test plan
- [ ] Next release merge to `main` produces exactly one "Create Release" run, succeeding